### PR TITLE
fix(deps): resolve SECURE-275 Next.js vulnerability

### DIFF
--- a/wizard/package-lock.json
+++ b/wizard/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tazworks-vid-integration-public",
-  "version": "0.1.0",
+  "version": "file:../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cerebruminc/cerebellum": "^15.16.1",
         "axios": "^1.13.6",
-        "next": "^14.2.35",
+        "next": "^15.5.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "save": "^2.9.0",
@@ -27,7 +27,7 @@
         "typescript": "^5.8.3"
       }
     },
-    "node_modules/@babel/runtime": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@babel/runtime": {
       "version": "7.27.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
       "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
@@ -36,7 +36,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime-corejs3": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@babel/runtime-corejs3": {
       "version": "7.27.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.27.4.tgz",
       "integrity": "sha512-H7QhL0ucCGOObsUETNbB2PuzF4gAvN8p32P6r91bX7M/hk4bx+3yz2hTwHL9d/Efzwu1upeb4/cd7oSxCzup3w==",
@@ -48,7 +48,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@biomejs/biome": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/biome": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
       "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
@@ -76,7 +76,7 @@
         "@biomejs/cli-win32-x64": "1.9.4"
       }
     },
-    "node_modules/@biomejs/cli-darwin-arm64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-darwin-arm64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
       "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
@@ -93,7 +93,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-darwin-x64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-darwin-x64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
       "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
@@ -110,7 +110,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-linux-arm64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-linux-arm64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
       "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
@@ -127,7 +127,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-linux-arm64-musl": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-linux-arm64-musl": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
       "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
@@ -144,7 +144,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-linux-x64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-linux-x64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
       "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
@@ -161,7 +161,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-linux-x64-musl": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-linux-x64-musl": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
       "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
@@ -178,7 +178,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-win32-arm64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-win32-arm64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
       "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
@@ -195,7 +195,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@biomejs/cli-win32-x64": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@biomejs/cli-win32-x64": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
       "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
@@ -212,7 +212,7 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@cerebruminc/cerebellum": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@cerebruminc/cerebellum": {
       "version": "15.19.0",
       "resolved": "https://registry.npmjs.org/@cerebruminc/cerebellum/-/cerebellum-15.19.0.tgz",
       "integrity": "sha512-Fs7C2tMKLPI2hfsr8yu5dSvaPtSwMGVa5Q7eM/lPsbSTe+ICnjYN+6bn7LYHcmPnM0pzRQ9kCMq/bPIdm938/A==",
@@ -251,7 +251,7 @@
         }
       }
     },
-    "node_modules/@cerebruminc/cerebellum/node_modules/dotenv": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@cerebruminc/cerebellum/node_modules/dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
@@ -260,7 +260,17 @@
         "node": ">=10"
       }
     },
-    "node_modules/@emotion/is-prop-valid": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
       "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
@@ -269,19 +279,19 @@
         "@emotion/memoize": "^0.8.1"
       }
     },
-    "node_modules/@emotion/memoize": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@emotion/memoize": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
       "license": "MIT"
     },
-    "node_modules/@emotion/unitless": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@emotion/unitless": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
       "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
       "license": "MIT"
     },
-    "node_modules/@floating-ui/core": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
@@ -289,7 +299,7 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
-    "node_modules/@floating-ui/dom": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@floating-ui/dom": {
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
@@ -298,7 +308,7 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
-    "node_modules/@floating-ui/react": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@floating-ui/react": {
       "version": "0.27.19",
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
       "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
@@ -312,7 +322,7 @@
         "react-dom": ">=17.0.0"
       }
     },
-    "node_modules/@floating-ui/react-dom": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
       "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
@@ -324,18 +334,18 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@floating-ui/utils": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@floating-ui/utils": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
-    "node_modules/@googlemaps/js-api-loader": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@googlemaps/js-api-loader": {
       "version": "1.16.8",
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
       "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@googlemaps/markerclusterer": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@googlemaps/markerclusterer": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.5.3.tgz",
       "integrity": "sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==",
@@ -345,131 +355,581 @@
         "supercluster": "^8.0.1"
       }
     },
-    "node_modules/@next/env": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
-      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
-      "license": "MIT"
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
-      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
-      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
-      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
-      "engines": {
-        "node": ">= 10"
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
-      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
-      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
-        "linux"
+        "darwin"
       ],
-      "engines": {
-        "node": ">= 10"
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
-      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
-        "x64"
+        "arm"
       ],
-      "license": "MIT",
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 10"
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
-      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/env": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
+      "license": "MIT"
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
+      "cpu": [
+        "arm64"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -479,10 +939,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -495,7 +955,7 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@react-google-maps/api": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@react-google-maps/api": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.20.6.tgz",
       "integrity": "sha512-frxkSHWbd36ayyxrEVopSCDSgJUT1tVKXvQld2IyzU3UnDuqqNA3AZE4/fCdqQb2/zBQx3nrWnZB1wBXDcrjcw==",
@@ -513,19 +973,19 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/@react-google-maps/infobox": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@react-google-maps/infobox": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.20.0.tgz",
       "integrity": "sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==",
       "license": "MIT"
     },
-    "node_modules/@react-google-maps/marker-clusterer": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@react-google-maps/marker-clusterer": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.20.0.tgz",
       "integrity": "sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==",
       "license": "MIT"
     },
-    "node_modules/@rjsf/core": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@rjsf/core": {
       "version": "5.24.10",
       "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.24.10.tgz",
       "integrity": "sha512-DJe2OECdDoBHacQKCPOAiuoEydM7ZJUUFqgcO4VswRs13QglRaEAEk4ylWR6f2gQx7wBg0u302n3VvRoHRxegQ==",
@@ -545,7 +1005,7 @@
         "react": "^16.14.0 || >=17"
       }
     },
-    "node_modules/@rjsf/utils": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@rjsf/utils": {
       "version": "5.24.10",
       "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.24.10.tgz",
       "integrity": "sha512-afsi+oKNV12p6OnBydJ0R4M87h7SaArqAhqJPqVXbMldnbPnW632THCtod5GG+IYtkqUkx0iQq2xpHw1OBf+3A==",
@@ -564,13 +1024,13 @@
         "react": "^16.14.0 || >=17"
       }
     },
-    "node_modules/@rjsf/utils/node_modules/react-is": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@rjsf/utils/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/@rjsf/validator-ajv8": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@rjsf/validator-ajv8": {
       "version": "5.24.10",
       "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.24.10.tgz",
       "integrity": "sha512-BLMpJNjtRAlp1i/QJBxY4/tchkWpZuJ/dJbjk+75veQ5oScr2YJ0/u2NqSsJNSyT37XxNJ6w49HgxZfB9xkDIQ==",
@@ -588,29 +1048,22 @@
         "@rjsf/utils": "^5.24.x"
       }
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
-    "node_modules/@types/google.maps": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/google.maps": {
       "version": "3.58.1",
       "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
       "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
       "license": "MIT"
     },
-    "node_modules/@types/hoist-non-react-statics": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
       "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
@@ -620,13 +1073,13 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
-    "node_modules/@types/lodash": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/lodash": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
       "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
       "license": "MIT"
     },
-    "node_modules/@types/node": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/node": {
       "version": "22.15.29",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
       "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
@@ -636,13 +1089,13 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
       "license": "MIT"
     },
-    "node_modules/@types/react": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
@@ -652,7 +1105,7 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-dom": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/react-dom": {
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
@@ -662,7 +1115,7 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/styled-components": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/styled-components": {
       "version": "5.1.34",
       "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
       "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
@@ -673,13 +1126,13 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/stylis": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/@types/stylis": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
       "license": "MIT"
     },
-    "node_modules/ajv": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
@@ -694,7 +1147,7 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-formats": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/ajv-formats": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
@@ -711,18 +1164,18 @@
         }
       }
     },
-    "node_modules/async": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "node_modules/attr-accept": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/attr-accept": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
       "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
@@ -731,7 +1184,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/axios": {
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
       "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
@@ -741,7 +1194,7 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/browser-image-compression": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/browser-image-compression": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
       "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
@@ -750,18 +1203,7 @@
         "uzip": "0.20201231.0"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
@@ -773,7 +1215,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/camelize": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
@@ -782,7 +1224,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caniuse-lite": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/caniuse-lite": {
       "version": "1.0.30001720",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
       "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
@@ -802,13 +1244,13 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/client-only": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
-    "node_modules/clsx": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
@@ -816,7 +1258,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/combined-stream": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
@@ -827,7 +1269,7 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/compute-gcd": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/compute-gcd": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
       "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
@@ -837,7 +1279,7 @@
         "validate.io-integer-array": "^1.0.0"
       }
     },
-    "node_modules/compute-lcm": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/compute-lcm": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
       "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
@@ -848,7 +1290,7 @@
         "validate.io-integer-array": "^1.0.0"
       }
     },
-    "node_modules/core-js-pure": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/core-js-pure": {
       "version": "3.42.0",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
       "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
@@ -859,13 +1301,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/country-flag-icons": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/country-flag-icons": {
       "version": "1.5.19",
       "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.5.19.tgz",
       "integrity": "sha512-D/ZkRyj+ywJC6b2IrAN3/tpbReMUqmuRLlcKFoY/o0+EPQN9Ev/e8tV+D3+9scvu/tarxwLErNwS73C3yzxs/g==",
       "license": "MIT"
     },
-    "node_modules/css-color-keywords": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
@@ -874,7 +1316,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/css-to-react-native": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
@@ -885,13 +1327,13 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "node_modules/csstype": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
-    "node_modules/date-fns": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
@@ -900,13 +1342,13 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/dayjs": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/deepmerge": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
@@ -915,7 +1357,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/delayed-stream": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
@@ -923,7 +1365,17 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/dotenv": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
@@ -936,7 +1388,7 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
@@ -949,13 +1401,13 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/duplexer": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
     },
-    "node_modules/es-define-property": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
@@ -963,7 +1415,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-errors": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
@@ -971,7 +1423,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-object-atoms": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
@@ -982,7 +1434,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-set-tostringtag": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
@@ -996,7 +1448,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/event-stream": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/event-stream": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
@@ -1011,13 +1463,13 @@
         "through": "^2.3.8"
       }
     },
-    "node_modules/fast-deep-equal": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/fast-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
@@ -1033,7 +1485,7 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/file-selector": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/file-selector": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
       "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
@@ -1045,7 +1497,7 @@
         "node": ">= 12"
       }
     },
-    "node_modules/follow-redirects": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
@@ -1064,7 +1516,7 @@
         }
       }
     },
-    "node_modules/form-data": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
@@ -1079,7 +1531,7 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formik": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/formik": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
       "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
@@ -1104,13 +1556,13 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/from": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "license": "MIT"
     },
-    "node_modules/function-bind": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
@@ -1118,7 +1570,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-intrinsic": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
@@ -1141,7 +1593,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-proto": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
@@ -1153,7 +1605,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/gopd": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
@@ -1164,13 +1616,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC"
-    },
-    "node_modules/has-symbols": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
@@ -1181,7 +1627,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
@@ -1195,7 +1641,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hasown": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
@@ -1206,7 +1652,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoist-non-react-statics": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
@@ -1215,7 +1661,7 @@
         "react-is": "^16.7.0"
       }
     },
-    "node_modules/imask": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
       "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
@@ -1227,13 +1673,13 @@
         "npm": ">=4.0.0"
       }
     },
-    "node_modules/immutability-helper": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/immutability-helper": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
       "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ==",
       "license": "MIT"
     },
-    "node_modules/invariant": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
@@ -1242,13 +1688,13 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "node_modules/js-tokens": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/json-schema-compare": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/json-schema-compare": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
       "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
@@ -1257,7 +1703,7 @@
         "lodash": "^4.17.4"
       }
     },
-    "node_modules/json-schema-merge-allof": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/json-schema-merge-allof": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
       "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
@@ -1271,13 +1717,13 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/json-schema-traverse": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/jsonpointer": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
@@ -1286,13 +1732,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kdbush": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/kdbush": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "license": "ISC"
     },
-    "node_modules/libheif-js": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/libheif-js": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.18.2.tgz",
       "integrity": "sha512-4Nk0dKhhRfVS4mECcX2jSDpNU6gcHQLneJjkGQq61N8COGtjSpSA3CI+1Q3kUYv5Vf+SwIqUtaDSdU6JO37c6w==",
@@ -1301,29 +1747,29 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/lodash": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
-    "node_modules/lodash-es": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
       "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
     },
-    "node_modules/lodash.assign": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
       "license": "MIT"
     },
-    "node_modules/lodash.debounce": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -1335,13 +1781,13 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/map-stream": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
       "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
       "license": "MIT"
     },
-    "node_modules/markdown-to-jsx": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/markdown-to-jsx": {
       "version": "7.7.6",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.7.6.tgz",
       "integrity": "sha512-/PWFFoKKMidk4Ut06F5hs5sluq1aJ0CGvUJWsnCK6hx/LPM8vlhvKAxtGHJ+U+V2Il2wmnfO6r81ICD3xZRVaw==",
@@ -1353,7 +1799,7 @@
         "react": ">= 0.14.0"
       }
     },
-    "node_modules/math-intrinsics": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
@@ -1361,7 +1807,7 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mime-db": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
@@ -1369,7 +1815,7 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mime-types": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
@@ -1380,19 +1826,19 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mingo": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/mingo": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.6.1.tgz",
       "integrity": "sha512-KC6b1ODYoSdYu5fBm+SzQb7fa4ARmGwfa3Cf9F7U+2mnfD4Zhf89qQgO1cPTtaJ68w3ntIT5dVujgF52HvN7+g==",
       "license": "MIT"
     },
-    "node_modules/nanoclone": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/nanoclone": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
       "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==",
       "license": "MIT"
     },
-    "node_modules/nanoid": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
@@ -1410,42 +1856,41 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/next": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
-      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/next": {
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.35",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
+        "@next/env": "15.5.15",
+        "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.6"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.33",
-        "@next/swc-darwin-x64": "14.2.33",
-        "@next/swc-linux-arm64-gnu": "14.2.33",
-        "@next/swc-linux-arm64-musl": "14.2.33",
-        "@next/swc-linux-x64-gnu": "14.2.33",
-        "@next/swc-linux-x64-musl": "14.2.33",
-        "@next/swc-win32-arm64-msvc": "14.2.33",
-        "@next/swc-win32-ia32-msvc": "14.2.33",
-        "@next/swc-win32-x64-msvc": "14.2.33"
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -1455,12 +1900,15 @@
         "@playwright/test": {
           "optional": true
         },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
         "sass": {
           "optional": true
         }
       }
     },
-    "node_modules/object-assign": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
@@ -1469,7 +1917,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/pause-stream": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
@@ -1481,13 +1929,13 @@
         "through": "~2.3"
       }
     },
-    "node_modules/picocolors": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
-    "node_modules/postcss": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
@@ -1515,13 +1963,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-value-parser": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
-    "node_modules/prop-types": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
@@ -1532,19 +1980,19 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/property-expr": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/property-expr": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
       "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
       "license": "MIT"
     },
-    "node_modules/proxy-from-env": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/react": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
@@ -1556,7 +2004,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-datepicker": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-datepicker": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.10.0.tgz",
       "integrity": "sha512-JIXuA+g+qP3c4MVJpx24o7n1gnv3WV/8A/D6964HucY1FlSEc30+ITPNUfbKZXYHl5rruCtxYCwi2lzn7gaz7g==",
@@ -1570,7 +2018,7 @@
         "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/react-dom": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
@@ -1583,7 +2031,7 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-dropzone": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-dropzone": {
       "version": "14.3.8",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
       "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
@@ -1600,13 +2048,13 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
-    "node_modules/react-fast-compare": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "license": "MIT"
     },
-    "node_modules/react-google-autocomplete": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-google-autocomplete": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/react-google-autocomplete/-/react-google-autocomplete-2.7.5.tgz",
       "integrity": "sha512-CPHMFBCgaJER19iA/y9Isjxh5au8mRxkt6przu9miOHLqrno+ifwJGXQOzMvtwdqNPXhb5Z6jpTtiJrbFeUvHg==",
@@ -1619,7 +2067,7 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/react-imask": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-imask": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
       "integrity": "sha512-vLNfzcCz62Yzx/GRGh5tiCph9Gbh2cZu+Tz8OiO5it2eNuuhpA0DWhhSlOtVtSJ80+Bx+vFK5De8eQ9AmbkXzA==",
@@ -1635,13 +2083,13 @@
         "react": ">=0.14.0"
       }
     },
-    "node_modules/react-is": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
-    "node_modules/react-places-autocomplete": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/react-places-autocomplete": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/react-places-autocomplete/-/react-places-autocomplete-7.3.0.tgz",
       "integrity": "sha512-86wcHC69JATvWBnIS/yCsBHLtwzOGcnx3Ye94u74yTrz1jLRC/txkVDkf6rvC+Jq3zNe/tAg/W53x0EaH1ZPPw==",
@@ -1654,7 +2102,7 @@
         "react": ">=0.14.7"
       }
     },
-    "node_modules/require-from-string": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
@@ -1663,7 +2111,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/save": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/save": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
       "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
@@ -1675,7 +2123,7 @@
         "mingo": "^6.1.0"
       }
     },
-    "node_modules/scheduler": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
@@ -1684,13 +2132,71 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/shallowequal": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
-    "node_modules/source-map-js": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
@@ -1699,7 +2205,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
@@ -1711,7 +2217,7 @@
         "node": "*"
       }
     },
-    "node_modules/stream-combiner": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/stream-combiner": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
@@ -1721,15 +2227,7 @@
         "through": "~2.3.4"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/styled-components": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/styled-components": {
       "version": "6.1.18",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.18.tgz",
       "integrity": "sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==",
@@ -1757,7 +2255,7 @@
         "react-dom": ">= 16.8.0"
       }
     },
-    "node_modules/styled-components/node_modules/postcss": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/styled-components/node_modules/postcss": {
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
@@ -1785,16 +2283,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/styled-components/node_modules/tslib": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/styled-components/node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
     },
-    "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -1803,7 +2301,7 @@
         "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -1814,13 +2312,13 @@
         }
       }
     },
-    "node_modules/stylis": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/stylis": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
       "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
       "license": "MIT"
     },
-    "node_modules/supercluster": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
@@ -1829,36 +2327,36 @@
         "kdbush": "^4.0.2"
       }
     },
-    "node_modules/tabbable": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
     },
-    "node_modules/through": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
-    "node_modules/tiny-warning": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
-    "node_modules/toposort": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "license": "MIT"
     },
-    "node_modules/tslib": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/typescript": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
@@ -1872,31 +2370,31 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uzip": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/uzip": {
       "version": "0.20201231.0",
       "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
       "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
-    "node_modules/validate.io-array": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/validate.io-array": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
       "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
       "license": "MIT"
     },
-    "node_modules/validate.io-function": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/validate.io-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
       "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
     },
-    "node_modules/validate.io-integer": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/validate.io-integer": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
       "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
@@ -1904,7 +2402,7 @@
         "validate.io-number": "^1.0.3"
       }
     },
-    "node_modules/validate.io-integer-array": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/validate.io-integer-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
       "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
@@ -1913,12 +2411,12 @@
         "validate.io-integer": "^1.0.4"
       }
     },
-    "node_modules/validate.io-number": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/validate.io-number": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
       "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
-    "node_modules/yup": {
+    "../../../../../../Volumes/owc-express-1m2/projects/local/tazworks-vid-integration-public/wizard/node_modules/yup": {
       "version": "0.32.11",
       "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
       "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",

--- a/wizard/package.json
+++ b/wizard/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@cerebruminc/cerebellum": "^15.16.1",
     "axios": "^1.13.6",
-    "next": "^14.2.35",
+    "next": "^15.5.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "save": "^2.9.0",


### PR DESCRIPTION
## Summary
- Resolve SECURE-275 by upgrading Next.js in the `wizard` app.

## Changes
- `wizard/package.json`
  - `next`: `^14.2.35` -> `^15.5.15`
- `wizard/package-lock.json`
  - refreshed dependency graph

## Validation
- `npm --prefix wizard ls next`
  - resolves to `next@15.5.15`
- `npm --prefix wizard audit --json`
  - no `next` vulnerability reported
- `npm --prefix wizard run tsc`
  - pass

## Ticket
- SECURE-275
